### PR TITLE
Patch for successive halving

### DIFF
--- a/dask_ml/datasets.py
+++ b/dask_ml/datasets.py
@@ -367,8 +367,9 @@ def make_classification(
     informative_idx = rng.choice(n_features, n_informative, chunks=n_informative)
     beta = (rng.random(n_features, chunks=n_features) - 1) * scale
 
-    informative_idx, beta = dask.compute(informative_idx, beta,
-                                         scheduler='single-threaded')
+    informative_idx, beta = dask.compute(
+        informative_idx, beta, scheduler="single-threaded"
+    )
 
     z0 = X[:, informative_idx].dot(beta[informative_idx])
     y = rng.random(z0.shape, chunks=chunks[0]) < 1 / (1 + da.exp(-z0))

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -74,7 +74,7 @@ def _fit(
     y_train,
     X_test,
     y_test,
-    get_partial_fit_calls,
+    additional_partial_fit_calls,
     fit_params=None,
     scorer=None,
     random_state=None,
@@ -182,7 +182,7 @@ def _fit(
 
         # Have we finished a full set of models?
         if len(speculative) == number_to_complete:
-            instructions = get_partial_fit_calls(info)
+            instructions = additional_partial_fit_calls(info)
 
             bad = set(models) - set(instructions)
 
@@ -247,15 +247,20 @@ def fit(*args, **kwargs):
         Numpy array or small dask array.  Should fit in memory.
     y_test : Array
         Numpy array or small dask array.  Should fit in memory.
-    start : int
-        Number of parameters to start with
+    additional_partial_fit_calls : callable
+        Function to determine how many more times to call ``model.partial_fit``
+        before calling this function again.
+
+        * Input: {model_id:  [{'partial_fit_calls': 0, 'params': {...},
+                               'model_id': model_id}
+                  for model_id in range(len(params))]]
+        * Output: {model_id: additional_partial_fit_calls
+                   for model_id in [...]}
+
     fit_params : dict
         Extra parameters to give to partial_fit
     random_state :
     scorer :
-    target : callable
-        A function that takes the start value and the current time step and
-        returns the number of desired models at that time step
 
     Examples
     --------

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -73,7 +73,7 @@ def _fit(
     y_train,
     X_test,
     y_test,
-    update,
+    adapt,
     fit_params=None,
     scorer=None,
     random_state=None,
@@ -184,7 +184,7 @@ def _fit(
 
         # Have we finished a full set of models?
         if len(speculative) == number_to_complete:
-            instructions = update(info)
+            instructions = adapt(info)
 
             bad = set(models) - set(instructions)
 
@@ -216,7 +216,7 @@ def _fit(
 
                     seq.add(score)
 
-            number_to_complete = len([v for k, v in instructions.items() if v])
+            number_to_complete = len([v for v in instructions.values() if v])
 
             speculative.clear()
 

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -62,7 +62,7 @@ def _create_model(model, ident, **params):
     """ Create a model by cloning and then setting params """
     with log_errors(pdb=True):
         model = clone(model).set_params(**params)
-        return model, {"model_id": ident, "params": params, "partial_fit_calls": -1}
+        return model, {"model_id": ident, "params": params, "partial_fit_calls": 0}
 
 
 @gen.coroutine

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -52,10 +52,11 @@ def _score(model_and_meta, X, y, scorer):
             score = scorer(model, X, y)
         else:
             score = model.score(X, y)
-        meta = dict(meta)
-        meta.update(score=score)
     except NotFittedError:
         assert meta['partial_fit_calls'] == 0
+        score = 0
+    meta = dict(meta)
+    meta.update(score=score)
     return meta
 
 

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -74,7 +74,7 @@ def _fit(
     y_train,
     X_test,
     y_test,
-    adapt,
+    get_partial_fit_calls,
     fit_params=None,
     scorer=None,
     random_state=None,
@@ -182,7 +182,7 @@ def _fit(
 
         # Have we finished a full set of models?
         if len(speculative) == number_to_complete:
-            instructions = adapt(info)
+            instructions = get_partial_fit_calls(info)
 
             bad = set(models) - set(instructions)
 

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -49,7 +49,7 @@ def test_basic(c, s, a, b):
 
     assert len(history) > 200
 
-    groups = toolz.groupby("time_step", history)
+    groups = toolz.groupby("partial_fit_calls", history)
     assert len(groups[0]) > len(groups[1]) > len(groups[2]) > len(groups[max(groups)])
     assert max(groups) > 10
 
@@ -86,7 +86,7 @@ def test_explicit(c, s, a, b):
 
     def update(scores):
         """ Progress through predefined updates, checking along the way """
-        ts = scores[0][-1]["time_step"]
+        ts = scores[0][-1]["partial_fit_calls"]
         if ts == 0:
             assert len(scores) == len(params)
             assert len(scores[0]) == 1
@@ -126,9 +126,9 @@ def test_explicit(c, s, a, b):
     model, meta = models[0]
 
     assert meta["params"] == {"alpha": 0.1}
-    assert meta["time_step"] == 6
+    assert meta["partial_fit_calls"] == 6
     assert len(models) == len(info) == 1
-    assert meta["time_step"] == history[-1]["time_step"]
+    assert meta["partial_fit_calls"] == history[-1]["partial_fit_calls"]
 
     while s.tasks or c.futures:  # all data clears out
         yield gen.sleep(0.01)


### PR DESCRIPTION
Changes this PR implements:

- meta keys `ident, time_step` => `model_id, partial_fit_calls` (and have `partial_fit_calls` be the number of times `model.partial_fit` has been called)
- ~~return all the meta objects returned by `_score` instead of only some of them~~
- if `model.score` throws a `ValueError`, make sure that `meta['partial_fit_calls'] == 0`.
- renames `update` to `additional_partial_fit_calls`.

I have a successive halving implementation working correctly with this implementation.

This PR isn't formally tested, and I'm only okay submitting it because it's for https://github.com/dask/dask-ml/pull/288/.